### PR TITLE
Makefiles: add OUTPUT_NAME and THIS_TASK, minor updates

### DIFF
--- a/03-H_Multi_GPU_Parallelization/.master/Makefile.in
+++ b/03-H_Multi_GPU_Parallelization/.master/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 03H-@@TASKSOL@@
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/03-H_Multi_GPU_Parallelization/.master/Makefile.in
+++ b/03-H_Multi_GPU_Parallelization/.master/Makefile.in
@@ -1,12 +1,10 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 03H-@@TASKSOL@@
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
-JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
-C_V_D ?= 0,1,2,3
+JSC_SUBMIT_CMD ?= srun --gres=gpu:4 --ntasks-per-node 4
 CUDA_HOME ?= /usr/local/cuda
-ifndef NVSHMEM_HOME
-$(error NVSHMEM_HOME is not set)
-endif
 ifndef MPI_HOME
 $(error MPI_HOME is not set)
 endif
@@ -26,8 +24,8 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -dc -Xcompiler -fopenmp -lineinfo -DUSE_NVTX -lnvToolsExt $(GENCODE_FLAGS) -std=c++14 -I$(NVSHMEM_HOME)/include -I$(MPI_HOME)/include
-NVCC_LDFLAGS = -ccbin=mpic++ -L$(NVSHMEM_HOME)/lib -lnvshmem -L$(MPI_HOME)/lib -lmpi -L$(CUDA_HOME)/lib64 -lcuda -lcudart -lnvToolsExt -lnvidia-ml
+NVCC_FLAGS += -dc -Xcompiler -fopenmp -lineinfo -DUSE_NVTX -lnvToolsExt $(GENCODE_FLAGS) -std=c++14  -I$(MPI_HOME)/include
+NVCC_LDFLAGS = -ccbin=mpic++ -L$(NVSHMEM_HOME)  -L$(MPI_HOME)/lib -lmpi -L$(CUDA_HOME)/lib64 -lcuda -lcudart -lnvToolsExt
 jacobi: Makefile jacobi.cu
 	$(NVCC) $(NVCC_FLAGS) jacobi.cu -c -o jacobi.o
 	$(NVCC) $(GENCODE_FLAGS) jacobi.o -o jacobi $(NVCC_LDFLAGS)
@@ -37,10 +35,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
+	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/03-H_Multi_GPU_Parallelization/.master/copy.mk
+++ b/03-H_Multi_GPU_Parallelization/.master/copy.mk
@@ -2,12 +2,12 @@
 # Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 TASKDIR = ../tasks/
 SOLUTIONDIR = ../solutions/
-OPT_SOLUTIONDIR = ../solutions/advanced
+OPT_SOLUTIONDIR = ../solutions/advanced/
 
 IYPNB_TEMPLATE = ../../.template.json
 
 PROCESSFILES = jacobi.cu
-COPYFILES = Makefile Instructions.ipynb Instructions.md
+COPYFILES = Instructions.ipynb Instructions.md
 
 
 TASKPROCCESFILES = $(addprefix $(TASKDIR)/,$(PROCESSFILES))
@@ -16,12 +16,19 @@ SOLUTIONPROCCESFILES = $(addprefix $(SOLUTIONDIR)/,$(PROCESSFILES))
 OPT_SOLUTIONPROCCESFILES = $(addprefix $(OPT_SOLUTIONDIR)/,$(PROCESSFILES))
 SOLUTIONCOPYFILES = $(addprefix $(SOLUTIONDIR)/,$(COPYFILES))
 OPT_SOLUTIONCOPYFILES = $(addprefix $(OPT_SOLUTIONDIR)/,$(COPYFILES))
+MAKEFILES = $(addsuffix /Makefile,$(TASKDIR) $(SOLUTIONDIR) $(OPT_SOLUTIONDIR))
 
 
 .PHONY: all task
 all: task
-task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES} ${OPT_SOLUTIONPROCCESFILES} ${OPT_SOLUTIONCOPYFILES}
+task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES} ${OPT_SOLUTIONPROCCESFILES} ${OPT_SOLUTIONCOPYFILES} ${MAKEFILES}
 
+$(TASKDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/task/' $< > $@
+$(SOLUTIONDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/sol/' $< > $@
+$(OPT_SOLUTIONDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/solopt/' $< > $@
 
 ${TASKPROCCESFILES}: $(PROCESSFILES)
 	mkdir -p $(TASKDIR)/

--- a/03-H_Multi_GPU_Parallelization/.master/copy.mk
+++ b/03-H_Multi_GPU_Parallelization/.master/copy.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 TASKDIR = ../tasks/
 SOLUTIONDIR = ../solutions/
 OPT_SOLUTIONDIR = ../solutions/advanced/

--- a/03-H_Multi_GPU_Parallelization/solutions/Makefile
+++ b/03-H_Multi_GPU_Parallelization/solutions/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 03H-sol
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/03-H_Multi_GPU_Parallelization/solutions/Makefile
+++ b/03-H_Multi_GPU_Parallelization/solutions/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 03H-sol
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --gres=gpu:4 --ntasks-per-node 4
@@ -33,10 +35,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/03-H_Multi_GPU_Parallelization/solutions/advanced/Makefile
+++ b/03-H_Multi_GPU_Parallelization/solutions/advanced/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 03H-solopt
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/03-H_Multi_GPU_Parallelization/solutions/advanced/Makefile
+++ b/03-H_Multi_GPU_Parallelization/solutions/advanced/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 03H-solopt
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --gres=gpu:4 --ntasks-per-node 4
@@ -33,10 +35,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/03-H_Multi_GPU_Parallelization/tasks/Makefile
+++ b/03-H_Multi_GPU_Parallelization/tasks/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 03H-task
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/03-H_Multi_GPU_Parallelization/tasks/Makefile
+++ b/03-H_Multi_GPU_Parallelization/tasks/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 03H-task
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --gres=gpu:4 --ntasks-per-node 4
@@ -33,10 +35,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/Instructions.ipynb
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/Instructions.ipynb
@@ -44,7 +44,9 @@
         "    target (`make profile`)\n",
         "3.  Open the recorded profile in the GUI\n",
         "    -   Either: Install Nsight Systems locally, and transfer the\n",
-        "        .qdrep/.nsys-rep file\n",
+        "        .nsys-rep file.\n",
+        "        -   *Note*: Right-click in file-browser, choose “Download” from\n",
+        "            context menu\n",
         "    -   Or: By running Xpra in your browser: In Jupyter, select “File \\>\n",
         "        New Launcher” and “Xpra Desktop”, which will open in a new tab.\n",
         "        Don’t forget to source the environment in your `xterm`.\n",
@@ -84,7 +86,7 @@
         "-   Destroy the additional cuda streams and events before ending the\n",
         "    application"
       ],
-      "id": "7563d35d-a670-47af-acef-44cee0450930"
+      "id": "21f77d33-b675-4746-9241-24837f172b29"
     }
   ],
   "nbformat": 4,

--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/Instructions.md
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/Instructions.md
@@ -31,7 +31,8 @@ Use the Nsight System profiler to profile the starting point version non-Overlap
 1. Start by compiling and running the application with `make run`
 1. Record an Nsight Systems profile, using the appropriate Makefile target (`make profile`)
 1. Open the recorded profile in the GUI
-    - Either: Install Nsight Systems locally, and transfer the .qdrep/.nsys-rep file
+    - Either: Install Nsight Systems locally, and transfer the .nsys-rep file.
+      - *Note*: Right-click in file-browser, choose "Download" from context menu
     - Or: By running Xpra in your browser: In Jupyter, select "File > New Launcher" and "Xpra Desktop", which will open in a new tab. Don't forget to source the environment in your `xterm`.
 1. Familiarize yourself with the different rows and the traces they represent. 
     - See if you can correlate a CUDA API kernel launch call and the resulting kernel execution on the device

--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/Makefile.in
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 06H-@@TASKSOL@@
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/Makefile.in
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/Makefile.in
@@ -1,10 +1,11 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 06H-@@TASKSOL@@
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
-JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
 MPICXX=mpicxx
+JSC_SUBMIT_CMD ?= srun --gres=gpu:4 --ntasks-per-node 4
 CUDA_HOME ?= /usr/local/cuda
-NCCL_HOME ?= /usr
 _JSCCOURSE_GPU_ARCH?=80
 GENCODE_SM30	:= -gencode arch=compute_30,code=sm_30
 GENCODE_SM35	:= -gencode arch=compute_35,code=sm_35
@@ -22,8 +23,8 @@ else
         NVCC_FLAGS = -DHAVE_CUB
 endif
 NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt -lnccl
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++14
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 
@@ -35,10 +36,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/copy.mk
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/copy.mk
@@ -6,18 +6,23 @@ SOLUTIONDIR = ../solutions/
 IYPNB_TEMPLATE = ../../.template.json
 
 PROCESSFILES = jacobi.cpp
-COPYFILES = Makefile Instructions.ipynb Instructions.md jacobi_kernels.cu
+COPYFILES = Instructions.ipynb Instructions.md jacobi_kernels.cu
 
 
 TASKPROCCESFILES = $(addprefix $(TASKDIR)/,$(PROCESSFILES))
 TASKCOPYFILES = $(addprefix $(TASKDIR)/,$(COPYFILES))
 SOLUTIONPROCCESFILES = $(addprefix $(SOLUTIONDIR)/,$(PROCESSFILES))
 SOLUTIONCOPYFILES = $(addprefix $(SOLUTIONDIR)/,$(COPYFILES))
+MAKEFILES = $(addsuffix /Makefile,$(TASKDIR) $(SOLUTIONDIR))
 
 .PHONY: all task clean
 all: task
-task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES}
+task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES} ${MAKEFILES}
 
+$(TASKDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/task/' $< > $@
+$(SOLUTIONDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/sol/' $< > $@
 
 ${TASKPROCCESFILES}: $(PROCESSFILES)
 	mkdir -p $(TASKDIR)/

--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/copy.mk
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/copy.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 TASKDIR = ../tasks/
 SOLUTIONDIR = ../solutions/
 

--- a/06-H_Overlap_Communication_and_Computation_MPI/solutions/Instructions.ipynb
+++ b/06-H_Overlap_Communication_and_Computation_MPI/solutions/Instructions.ipynb
@@ -44,7 +44,9 @@
         "    target (`make profile`)\n",
         "3.  Open the recorded profile in the GUI\n",
         "    -   Either: Install Nsight Systems locally, and transfer the\n",
-        "        .qdrep/.nsys-rep file\n",
+        "        .nsys-rep file.\n",
+        "        -   *Note*: Right-click in file-browser, choose “Download” from\n",
+        "            context menu\n",
         "    -   Or: By running Xpra in your browser: In Jupyter, select “File \\>\n",
         "        New Launcher” and “Xpra Desktop”, which will open in a new tab.\n",
         "        Don’t forget to source the environment in your `xterm`.\n",
@@ -84,7 +86,7 @@
         "-   Destroy the additional cuda streams and events before ending the\n",
         "    application"
       ],
-      "id": "7563d35d-a670-47af-acef-44cee0450930"
+      "id": "21f77d33-b675-4746-9241-24837f172b29"
     }
   ],
   "nbformat": 4,

--- a/06-H_Overlap_Communication_and_Computation_MPI/solutions/Instructions.md
+++ b/06-H_Overlap_Communication_and_Computation_MPI/solutions/Instructions.md
@@ -31,7 +31,8 @@ Use the Nsight System profiler to profile the starting point version non-Overlap
 1. Start by compiling and running the application with `make run`
 1. Record an Nsight Systems profile, using the appropriate Makefile target (`make profile`)
 1. Open the recorded profile in the GUI
-    - Either: Install Nsight Systems locally, and transfer the .qdrep/.nsys-rep file
+    - Either: Install Nsight Systems locally, and transfer the .nsys-rep file.
+      - *Note*: Right-click in file-browser, choose "Download" from context menu
     - Or: By running Xpra in your browser: In Jupyter, select "File > New Launcher" and "Xpra Desktop", which will open in a new tab. Don't forget to source the environment in your `xterm`.
 1. Familiarize yourself with the different rows and the traces they represent. 
     - See if you can correlate a CUDA API kernel launch call and the resulting kernel execution on the device

--- a/06-H_Overlap_Communication_and_Computation_MPI/solutions/Makefile
+++ b/06-H_Overlap_Communication_and_Computation_MPI/solutions/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 06H-sol
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
 MPICXX=mpicxx
@@ -34,10 +36,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/06-H_Overlap_Communication_and_Computation_MPI/solutions/Makefile
+++ b/06-H_Overlap_Communication_and_Computation_MPI/solutions/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 06H-sol
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/06-H_Overlap_Communication_and_Computation_MPI/tasks/Instructions.ipynb
+++ b/06-H_Overlap_Communication_and_Computation_MPI/tasks/Instructions.ipynb
@@ -44,7 +44,9 @@
         "    target (`make profile`)\n",
         "3.  Open the recorded profile in the GUI\n",
         "    -   Either: Install Nsight Systems locally, and transfer the\n",
-        "        .qdrep/.nsys-rep file\n",
+        "        .nsys-rep file.\n",
+        "        -   *Note*: Right-click in file-browser, choose “Download” from\n",
+        "            context menu\n",
         "    -   Or: By running Xpra in your browser: In Jupyter, select “File \\>\n",
         "        New Launcher” and “Xpra Desktop”, which will open in a new tab.\n",
         "        Don’t forget to source the environment in your `xterm`.\n",
@@ -84,7 +86,7 @@
         "-   Destroy the additional cuda streams and events before ending the\n",
         "    application"
       ],
-      "id": "7563d35d-a670-47af-acef-44cee0450930"
+      "id": "21f77d33-b675-4746-9241-24837f172b29"
     }
   ],
   "nbformat": 4,

--- a/06-H_Overlap_Communication_and_Computation_MPI/tasks/Instructions.md
+++ b/06-H_Overlap_Communication_and_Computation_MPI/tasks/Instructions.md
@@ -31,7 +31,8 @@ Use the Nsight System profiler to profile the starting point version non-Overlap
 1. Start by compiling and running the application with `make run`
 1. Record an Nsight Systems profile, using the appropriate Makefile target (`make profile`)
 1. Open the recorded profile in the GUI
-    - Either: Install Nsight Systems locally, and transfer the .qdrep/.nsys-rep file
+    - Either: Install Nsight Systems locally, and transfer the .nsys-rep file.
+      - *Note*: Right-click in file-browser, choose "Download" from context menu
     - Or: By running Xpra in your browser: In Jupyter, select "File > New Launcher" and "Xpra Desktop", which will open in a new tab. Don't forget to source the environment in your `xterm`.
 1. Familiarize yourself with the different rows and the traces they represent. 
     - See if you can correlate a CUDA API kernel launch call and the resulting kernel execution on the device

--- a/06-H_Overlap_Communication_and_Computation_MPI/tasks/Makefile
+++ b/06-H_Overlap_Communication_and_Computation_MPI/tasks/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 06H-task
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
 MPICXX=mpicxx
@@ -34,10 +36,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/06-H_Overlap_Communication_and_Computation_MPI/tasks/Makefile
+++ b/06-H_Overlap_Communication_and_Computation_MPI/tasks/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 06H-task
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/08-H_NCCL_NVSHMEM/.master/NCCL/Makefile.in
+++ b/08-H_NCCL_NVSHMEM/.master/NCCL/Makefile.in
@@ -1,4 +1,6 @@
-# Copyright (c) 2021,2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 08H-NCCL-@@TASKSOL@@
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
@@ -35,10 +37,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx --cuda-graph-trace=node -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/08-H_NCCL_NVSHMEM/.master/NCCL/Makefile.in
+++ b/08-H_NCCL_NVSHMEM/.master/NCCL/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 08H-NCCL-@@TASKSOL@@
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/08-H_NCCL_NVSHMEM/.master/NCCL/copy.mk
+++ b/08-H_NCCL_NVSHMEM/.master/NCCL/copy.mk
@@ -6,18 +6,23 @@ SOLUTIONDIR = ../../solutions/NCCL
 IYPNB_TEMPLATE = ../../../.template.json
 
 PROCESSFILES = jacobi.cpp
-COPYFILES = Makefile jacobi_kernels.cu Instructions.ipynb Instructions.md
+COPYFILES = jacobi_kernels.cu Instructions.ipynb Instructions.md
 
 
 TASKPROCCESFILES = $(addprefix $(TASKDIR)/,$(PROCESSFILES))
 TASKCOPYFILES = $(addprefix $(TASKDIR)/,$(COPYFILES))
 SOLUTIONPROCCESFILES = $(addprefix $(SOLUTIONDIR)/,$(PROCESSFILES))
 SOLUTIONCOPYFILES = $(addprefix $(SOLUTIONDIR)/,$(COPYFILES))
+MAKEFILES = $(addsuffix /Makefile,$(TASKDIR) $(SOLUTIONDIR))
 
 .PHONY: all task
 all: task
-task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES}
+task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES} ${MAKEFILES}
 
+$(TASKDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/task/' $< > $@
+$(SOLUTIONDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/sol/' $< > $@
 
 ${TASKPROCCESFILES}: $(PROCESSFILES)
 	mkdir -p $(TASKDIR)/

--- a/08-H_NCCL_NVSHMEM/.master/NCCL/copy.mk
+++ b/08-H_NCCL_NVSHMEM/.master/NCCL/copy.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 TASKDIR = ../../tasks/NCCL
 SOLUTIONDIR = ../../solutions/NCCL
 

--- a/08-H_NCCL_NVSHMEM/.master/NVSHMEM/Makefile.in
+++ b/08-H_NCCL_NVSHMEM/.master/NVSHMEM/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, All rights reserved.
 THIS_TASK := 08H-NVSHMEM-@@TASKSOL@@
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/08-H_NCCL_NVSHMEM/.master/NVSHMEM/Makefile.in
+++ b/08-H_NCCL_NVSHMEM/.master/NVSHMEM/Makefile.in
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 08H-NVSHMEM-@@TASKSOL@@
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 N_D_C_VMM=1 #Enabled to hide warning and errors only found in  NVSHMEM/2.5.0 to be fixed in next release
@@ -38,10 +40,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/08-H_NCCL_NVSHMEM/.master/NVSHMEM/copy.mk
+++ b/08-H_NCCL_NVSHMEM/.master/NVSHMEM/copy.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 TASKDIR = ../../tasks/NVSHMEM
 SOLUTIONDIR = ../../solutions/NVSHMEM
 

--- a/08-H_NCCL_NVSHMEM/.master/NVSHMEM/copy.mk
+++ b/08-H_NCCL_NVSHMEM/.master/NVSHMEM/copy.mk
@@ -6,18 +6,23 @@ SOLUTIONDIR = ../../solutions/NVSHMEM
 IYPNB_TEMPLATE = ../../../.template.json
 
 PROCESSFILES = jacobi.cu
-COPYFILES = Makefile Instructions.ipynb Instructions.md
+COPYFILES = Instructions.ipynb Instructions.md
 
 
 TASKPROCCESFILES = $(addprefix $(TASKDIR)/,$(PROCESSFILES))
 TASKCOPYFILES = $(addprefix $(TASKDIR)/,$(COPYFILES))
 SOLUTIONPROCCESFILES = $(addprefix $(SOLUTIONDIR)/,$(PROCESSFILES))
 SOLUTIONCOPYFILES = $(addprefix $(SOLUTIONDIR)/,$(COPYFILES))
+MAKEFILES = $(addsuffix /Makefile,$(TASKDIR) $(SOLUTIONDIR))
 
 .PHONY: all task
 all: task
-task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES}
+task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES} ${MAKEFILES}
 
+$(TASKDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/task/' $< > $@
+$(SOLUTIONDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/sol/' $< > $@
 
 ${TASKPROCCESFILES}: $(PROCESSFILES)
 	mkdir -p $(TASKDIR)/

--- a/08-H_NCCL_NVSHMEM/solutions/NCCL/Makefile
+++ b/08-H_NCCL_NVSHMEM/solutions/NCCL/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 08H-NCCL-sol
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
@@ -35,10 +37,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/08-H_NCCL_NVSHMEM/solutions/NCCL/Makefile
+++ b/08-H_NCCL_NVSHMEM/solutions/NCCL/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 08H-NCCL-sol
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/08-H_NCCL_NVSHMEM/solutions/NVSHMEM/Makefile
+++ b/08-H_NCCL_NVSHMEM/solutions/NVSHMEM/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 08H-NVSHMEM-sol
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 N_D_C_VMM=1 #Enabled to hide warning and errors only found in  NVSHMEM/2.5.0 to be fixed in next release
@@ -38,10 +40,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/08-H_NCCL_NVSHMEM/solutions/NVSHMEM/Makefile
+++ b/08-H_NCCL_NVSHMEM/solutions/NVSHMEM/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, All rights reserved.
 THIS_TASK := 08H-NVSHMEM-sol
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/08-H_NCCL_NVSHMEM/tasks/NCCL/Makefile
+++ b/08-H_NCCL_NVSHMEM/tasks/NCCL/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 08H-NCCL-task
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
@@ -35,10 +37,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/08-H_NCCL_NVSHMEM/tasks/NCCL/Makefile
+++ b/08-H_NCCL_NVSHMEM/tasks/NCCL/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 08H-NCCL-task
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/08-H_NCCL_NVSHMEM/tasks/NVSHMEM/Makefile
+++ b/08-H_NCCL_NVSHMEM/tasks/NVSHMEM/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 08H-NVSHMEM-task
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 N_D_C_VMM=1 #Enabled to hide warning and errors only found in  NVSHMEM/2.5.0 to be fixed in next release
@@ -38,10 +40,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/08-H_NCCL_NVSHMEM/tasks/NVSHMEM/Makefile
+++ b/08-H_NCCL_NVSHMEM/tasks/NVSHMEM/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, All rights reserved.
 THIS_TASK := 08H-NVSHMEM-task
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/Makefile.in
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 10H-NVSHMEM-@@TASKSOL@@
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/Makefile.in
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/Makefile.in
@@ -1,8 +1,14 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 10H-NVSHMEM-@@TASKSOL@@
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
-JSC_SUBMIT_CMD ?= srun --gres=gpu:4 --ntasks-per-node 4
+JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
+C_V_D ?= 0,1,2,3
 CUDA_HOME ?= /usr/local/cuda
+ifndef NVSHMEM_HOME
+$(error NVSHMEM_HOME is not set)
+endif
 ifndef MPI_HOME
 $(error MPI_HOME is not set)
 endif
@@ -22,8 +28,8 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -dc -Xcompiler -fopenmp -lineinfo -DUSE_NVTX -lnvToolsExt $(GENCODE_FLAGS) -std=c++14  -I$(MPI_HOME)/include
-NVCC_LDFLAGS = -ccbin=mpic++ -L$(NVSHMEM_HOME)  -L$(MPI_HOME)/lib -lmpi -L$(CUDA_HOME)/lib64 -lcuda -lcudart -lnvToolsExt
+NVCC_FLAGS += -dc -Xcompiler -fopenmp -lineinfo -DUSE_NVTX -lnvToolsExt $(GENCODE_FLAGS) -std=c++14 -I$(NVSHMEM_HOME)/include -I$(MPI_HOME)/include
+NVCC_LDFLAGS = -ccbin=mpic++ -L$(NVSHMEM_HOME)/lib -lnvshmem -L$(MPI_HOME)/lib -lmpi -L$(CUDA_HOME)/lib64 -lcuda -lcudart -lnvToolsExt -lnvidia-ml
 jacobi: Makefile jacobi.cu
 	$(NVCC) $(NVCC_FLAGS) jacobi.cu -c -o jacobi.o
 	$(NVCC) $(GENCODE_FLAGS) jacobi.o -o jacobi $(NVCC_LDFLAGS)
@@ -33,10 +39,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/copy.mk
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/copy.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 TASKDIR = ../../tasks/Device-initiated_Communication_with_NVSHMEM
 SOLUTIONDIR = ../../solutions/Device-initiated_Communication_with_NVSHMEM
 

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/copy.mk
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Device-initiated_Communication_with_NVSHMEM/copy.mk
@@ -6,18 +6,23 @@ SOLUTIONDIR = ../../solutions/Device-initiated_Communication_with_NVSHMEM
 IYPNB_TEMPLATE = ../../../.template.json
 
 PROCESSFILES = jacobi.cu
-COPYFILES = Makefile Instructions.ipynb Instructions.md
+COPYFILES = Instructions.ipynb Instructions.md
 
 
 TASKPROCCESFILES = $(addprefix $(TASKDIR)/,$(PROCESSFILES))
 TASKCOPYFILES = $(addprefix $(TASKDIR)/,$(COPYFILES))
 SOLUTIONPROCCESFILES = $(addprefix $(SOLUTIONDIR)/,$(PROCESSFILES))
 SOLUTIONCOPYFILES = $(addprefix $(SOLUTIONDIR)/,$(COPYFILES))
+MAKEFILES = $(addsuffix /Makefile,$(TASKDIR) $(SOLUTIONDIR))
 
 .PHONY: all task
 all: task
-task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES}
+task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES} ${MAKEFILES}
 
+$(TASKDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/task/' $< > $@
+$(SOLUTIONDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/sol/' $< > $@
 
 ${TASKPROCCESFILES}: $(PROCESSFILES)
 	mkdir -p $(TASKDIR)/

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/Makefile.in
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/Makefile.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2021,2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 10H-Graphs-@@TASKSOL@@
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/Makefile.in
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/Makefile.in
@@ -1,9 +1,12 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021,2022, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 10H-Graphs-@@TASKSOL@@
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
+JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
 MPICXX=mpicxx
-JSC_SUBMIT_CMD ?= srun --gres=gpu:4 --ntasks-per-node 4
 CUDA_HOME ?= /usr/local/cuda
+NCCL_HOME ?= /usr
 _JSCCOURSE_GPU_ARCH?=80
 GENCODE_SM30	:= -gencode arch=compute_30,code=sm_30
 GENCODE_SM35	:= -gencode arch=compute_35,code=sm_35
@@ -21,8 +24,8 @@ else
         NVCC_FLAGS = -DHAVE_CUB
 endif
 NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++14
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt -lnccl
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 
@@ -34,10 +37,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx --cuda-graph-trace=node -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/copy.mk
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/copy.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION. All rights reserved.
 TASKDIR = ../../tasks/Using_CUDA_Graphs
 SOLUTIONDIR = ../../solutions/Using_CUDA_Graphs
 

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/copy.mk
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/.master/Using_CUDA_Graphs/copy.mk
@@ -6,18 +6,23 @@ SOLUTIONDIR = ../../solutions/Using_CUDA_Graphs
 IYPNB_TEMPLATE = ../../../.template.json
 
 PROCESSFILES = jacobi.cpp
-COPYFILES = Makefile jacobi_kernels.cu Instructions.ipynb Instructions.md
+COPYFILES = jacobi_kernels.cu Instructions.ipynb Instructions.md
 
 
 TASKPROCCESFILES = $(addprefix $(TASKDIR)/,$(PROCESSFILES))
 TASKCOPYFILES = $(addprefix $(TASKDIR)/,$(COPYFILES))
 SOLUTIONPROCCESFILES = $(addprefix $(SOLUTIONDIR)/,$(PROCESSFILES))
 SOLUTIONCOPYFILES = $(addprefix $(SOLUTIONDIR)/,$(COPYFILES))
+MAKEFILES = $(addsuffix /Makefile,$(TASKDIR) $(SOLUTIONDIR))
 
 .PHONY: all task
 all: task
-task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES}
+task: ${TASKPROCCESFILES} ${TASKCOPYFILES} ${SOLUTIONPROCCESFILES} ${SOLUTIONCOPYFILES} ${MAKEFILES}
 
+$(TASKDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/task/' $< > $@
+$(SOLUTIONDIR)/Makefile: Makefile.in
+	sed -e 's/@@TASKSOL@@/sol/' $< > $@
 
 ${TASKPROCCESFILES}: $(PROCESSFILES)
 	mkdir -p $(TASKDIR)/

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Device-initiated_Communication_with_NVSHMEM/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Device-initiated_Communication_with_NVSHMEM/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 10H-NVSHMEM-sol
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Device-initiated_Communication_with_NVSHMEM/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Device-initiated_Communication_with_NVSHMEM/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 10H-NVSHMEM-sol
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
@@ -37,10 +39,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Using_CUDA_Graphs/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Using_CUDA_Graphs/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2021,2022, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 10H-Graphs-sol
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
@@ -35,10 +37,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx --cuda-graph-trace=node -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx --cuda-graph-trace=node -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Using_CUDA_Graphs/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/solutions/Using_CUDA_Graphs/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021,2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 10H-Graphs-sol
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Device-initiated_Communication_with_NVSHMEM/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Device-initiated_Communication_with_NVSHMEM/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 10H-NVSHMEM-task
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Device-initiated_Communication_with_NVSHMEM/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Device-initiated_Communication_with_NVSHMEM/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 10H-NVSHMEM-task
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
@@ -37,10 +39,10 @@ clean:
 	rm -f jacobi jacobi.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	CUDA_VISIBLE_DEVICES=$(C_V_D) $(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Using_CUDA_Graphs/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Using_CUDA_Graphs/Makefile
@@ -1,4 +1,6 @@
 # Copyright (c) 2021,2022, NVIDIA CORPORATION. All rights reserved.
+THIS_TASK := 10H-Graphs-task
+OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
@@ -35,10 +37,10 @@ clean:
 	rm -f jacobi jacobi_kernels.o *.nsys-rep jacobi.*.compute-sanitizer.log
 
 sanitize: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file jacobi.%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) compute-sanitizer --log-file $(OUTPUT_NAME).%q{SLURM_PROCID}.compute-sanitizer.log ./jacobi -niter 10
 
 run: jacobi
 	$(JSC_SUBMIT_CMD) -n $(NP) ./jacobi
 
 profile: jacobi
-	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx --cuda-graph-trace=node -o jacobi.%q{SLURM_PROCID} ./jacobi -niter 10
+	$(JSC_SUBMIT_CMD) -n $(NP) nsys profile --trace=mpi,cuda,nvtx --cuda-graph-trace=node -o $(OUTPUT_NAME).%q{SLURM_PROCID} ./jacobi -niter 10

--- a/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Using_CUDA_Graphs/Makefile
+++ b/10-H_CUDA_Graphs_and_Device-initiated_Communication_with_NVSHMEM/tasks/Using_CUDA_Graphs/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2021,2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 10H-Graphs-task
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
 NP ?= 1


### PR DESCRIPTION
Modify all hands-on Makefiles to include current task and dynamic output file name so that
any output generated by tasks can be distinguished (and not all files have the same name).
* All existing .master/Makefile renamed to Makefile.in
* Add @@TASKSOL@@ replacement pattern to Makefile.in
* Running copy.mk preprocesses replacement pattern depending on destination (task/sol)
* Use OUTPUT_NAME with exercise and timestamp, e.g. jacobi.08H-NCCL-sol__20241114-1951.0.nsys-rep

Minor:
* Fix 06-H Readme