### PR TITLE
Updates  to tutorial 06 to work with CUDA 13

### DIFF
--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/Makefile.in
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/Makefile.in
@@ -22,9 +22,9 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt
+NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++17 -I$(CUDA_HOME)/include
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++17
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart 
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 

--- a/06-H_Overlap_Communication_and_Computation_MPI/.master/jacobi.cpp
+++ b/06-H_Overlap_Communication_and_Computation_MPI/.master/jacobi.cpp
@@ -56,7 +56,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 const uint32_t colors[] = {0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff,
                            0x0000ffff, 0x00ff0000, 0x00ffffff};

--- a/06-H_Overlap_Communication_and_Computation_MPI/solutions/Makefile
+++ b/06-H_Overlap_Communication_and_Computation_MPI/solutions/Makefile
@@ -22,9 +22,9 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt
+NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++17 -I$(CUDA_HOME)/include
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++17
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart 
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 

--- a/06-H_Overlap_Communication_and_Computation_MPI/solutions/jacobi.cpp
+++ b/06-H_Overlap_Communication_and_Computation_MPI/solutions/jacobi.cpp
@@ -56,7 +56,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 const uint32_t colors[] = {0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff,
                            0x0000ffff, 0x00ff0000, 0x00ffffff};

--- a/06-H_Overlap_Communication_and_Computation_MPI/tasks/Makefile
+++ b/06-H_Overlap_Communication_and_Computation_MPI/tasks/Makefile
@@ -22,9 +22,9 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt
+NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++17 -I$(CUDA_HOME)/include
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -std=c++17
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart 
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 

--- a/06-H_Overlap_Communication_and_Computation_MPI/tasks/jacobi.cpp
+++ b/06-H_Overlap_Communication_and_Computation_MPI/tasks/jacobi.cpp
@@ -56,7 +56,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 const uint32_t colors[] = {0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff,
                            0x0000ffff, 0x00ff0000, 0x00ffffff};


### PR DESCRIPTION
Updated files:

 -   Makefile.in
 -   jacobi.cu
 -   Across all folders -> .master, solutions, tasks

Changes:

  -  Add `$(CUDA_HOME)/include` to NVCC flags (For the `nvtx3/nvToolsExt.h` header)
  -  Remove the linking to `nvToolsExt` from NVCC_LDFLAGS (no longer supported in CUDA 13.x) and NVCC_FLAGS
  -  Update the include in jacobi.cu to reflect the new library structure
  -  Update to use C++17 (required for Thrust)
