### PR TITLE
changes to accomodate for cuda 13 (NCCL)

### DIFF
--- a/08-H_NCCL_NVSHMEM/.master/NCCL/Makefile.in
+++ b/08-H_NCCL_NVSHMEM/.master/NCCL/Makefile.in
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 08H-NCCL-@@TASKSOL@@
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
-NP ?= 1
+NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
 MPICXX=mpicxx
@@ -23,9 +23,9 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt -lnccl
+NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++17 -I$(CUDA_HOME)/include
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++17
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart  -lnccl
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 

--- a/08-H_NCCL_NVSHMEM/.master/NCCL/jacobi.cpp
+++ b/08-H_NCCL_NVSHMEM/.master/NCCL/jacobi.cpp
@@ -55,7 +55,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 const uint32_t colors[] = {0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff,
                            0x0000ffff, 0x00ff0000, 0x00ffffff};

--- a/08-H_NCCL_NVSHMEM/solutions/NCCL/Makefile
+++ b/08-H_NCCL_NVSHMEM/solutions/NCCL/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 08H-NCCL-sol
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
-NP ?= 1
+NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
 MPICXX=mpicxx
@@ -23,9 +23,9 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt -lnccl
+NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++17 -I$(CUDA_HOME)/include
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++17
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart  -lnccl
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 

--- a/08-H_NCCL_NVSHMEM/solutions/NCCL/jacobi.cpp
+++ b/08-H_NCCL_NVSHMEM/solutions/NCCL/jacobi.cpp
@@ -55,7 +55,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 const uint32_t colors[] = {0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff,
                            0x0000ffff, 0x00ff0000, 0x00ffffff};

--- a/08-H_NCCL_NVSHMEM/tasks/NCCL/Makefile
+++ b/08-H_NCCL_NVSHMEM/tasks/NCCL/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2024, NVIDIA CORPORATION. All rights reserved.
 THIS_TASK := 08H-NCCL-task
 OUTPUT_NAME := jacobi.$(THIS_TASK)__$(shell date '+%Y%m%d-%H%M')
-NP ?= 1
+NP ?= 4
 NVCC=nvcc
 JSC_SUBMIT_CMD ?= srun --cpu-bind=socket --gres=gpu:4 --ntasks-per-node 4
 MPICXX=mpicxx
@@ -23,9 +23,9 @@ ifdef DISABLE_CUB
 else
         NVCC_FLAGS = -DHAVE_CUB
 endif
-NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++14
-MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++14
-LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart -lnvToolsExt -lnccl
+NVCC_FLAGS += -lineinfo $(GENCODE_FLAGS) -std=c++17 -I$(CUDA_HOME)/include
+MPICXX_FLAGS = -DUSE_NVTX -I$(CUDA_HOME)/include -I$(NCCL_HOME)/include -std=c++17
+LD_FLAGS = -L$(CUDA_HOME)/lib64 -lcudart  -lnccl
 jacobi: Makefile jacobi.cpp jacobi_kernels.o
 	$(MPICXX) $(MPICXX_FLAGS) jacobi.cpp jacobi_kernels.o $(LD_FLAGS) -o jacobi
 

--- a/08-H_NCCL_NVSHMEM/tasks/NCCL/jacobi.cpp
+++ b/08-H_NCCL_NVSHMEM/tasks/NCCL/jacobi.cpp
@@ -55,7 +55,7 @@
 #include <cuda_runtime.h>
 
 #ifdef USE_NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 
 const uint32_t colors[] = {0x0000ff00, 0x000000ff, 0x00ffff00, 0x00ff00ff,
                            0x0000ffff, 0x00ff0000, 0x00ffffff};


### PR DESCRIPTION
Updates to work with CUDA 13:

- removed the link to `nvExtTools`
- Added `$(CUDA_HOME)/include` to NVCC flags
- Changed NVTX header to `nvtx3/nvToolsExt.h`
- update c++ standard to 17 (so Thrust doesn't complain)